### PR TITLE
Enhancements to User Management Security and Testing

### DIFF
--- a/src/api/v1/user/__test__/restore-user.test.ts
+++ b/src/api/v1/user/__test__/restore-user.test.ts
@@ -1,0 +1,86 @@
+import { defaultUsers } from '@/constants';
+import {
+  createUser,
+  expectUserNotFoundError,
+  expectFindUserByUsernameSuccess,
+  expectLoginSuccess,
+  expectUnauthorizedResponseForInvalidAuthorizationHeader,
+  expectUnauthorizedResponseForMissingAuthorizationHeader,
+  expectUnauthorizedResponseWhenUserHasInsufficientPermission,
+  expectUserCreationSuccess,
+  findUserByUsername,
+  login,
+  verifyAccount,
+  expectBadRequestResponseForValidationError,
+  restoreUser,
+  expectRestoreUserSuccess,
+} from '@/utils/test';
+import { GetUser } from '../user.validation';
+import mongoose from 'mongoose';
+
+const newUser = {
+  username: 'username',
+  email: 'validemail@example.com',
+  password: 'ValidPassword123!',
+  confirmPassword: 'ValidPassword123!',
+};
+
+describe('Restore User', () => {
+  let authorizationHeader: string;
+  let userToDelete: GetUser;
+
+  beforeAll(async () => {
+    const loginResponse = await login(defaultUsers);
+    expectLoginSuccess(loginResponse);
+    authorizationHeader = `Bearer ${loginResponse.header['authorization']}`;
+
+    const userResponse = await createUser(newUser, authorizationHeader);
+    expectUserCreationSuccess(userResponse, newUser);
+
+    const foundUserRes = await findUserByUsername(newUser.username);
+    expectFindUserByUsernameSuccess(foundUserRes, newUser);
+
+    userToDelete = foundUserRes.body.user;
+  });
+
+  it('should return 401 for missing authorization header', async () => {
+    const response = await restoreUser(userToDelete.id, '');
+    expectUnauthorizedResponseForMissingAuthorizationHeader(response);
+  });
+
+  it('should return 401 for invalid authorization header', async () => {
+    const response = await restoreUser(userToDelete.id, 'invalid');
+    expectUnauthorizedResponseForInvalidAuthorizationHeader(response);
+  });
+
+  it('should return 400 for invalid user id', async () => {
+    const response = await restoreUser('invalid', authorizationHeader);
+    expectBadRequestResponseForValidationError(response);
+  });
+
+  it('should return 404 for user not found', async () => {
+    const response = await restoreUser(new mongoose.Types.ObjectId().toHexString(), authorizationHeader);
+    expectUserNotFoundError(response);
+  });
+
+  it('should return 403 for unauthorized user', async () => {
+    const unAuthorizedUser = { ...newUser, username: 'unauthorized', email: 'unauthorized@gmail.com' };
+
+    const createUserRes = await createUser(unAuthorizedUser, authorizationHeader);
+    expectUserCreationSuccess(createUserRes, unAuthorizedUser);
+
+    await verifyAccount(unAuthorizedUser);
+
+    const loginResponse = await login(unAuthorizedUser);
+    expectLoginSuccess(loginResponse);
+    const header = `Bearer ${loginResponse.header['authorization']}`;
+
+    const restoreUserRes = await restoreUser(userToDelete.id, header);
+    expectUnauthorizedResponseWhenUserHasInsufficientPermission(restoreUserRes);
+  });
+
+  it('should soft delete user', async () => {
+    const response = await restoreUser(userToDelete.id, authorizationHeader);
+    expectRestoreUserSuccess(response);
+  });
+});

--- a/src/api/v1/user/__test__/soft-delete-user.test.ts
+++ b/src/api/v1/user/__test__/soft-delete-user.test.ts
@@ -1,0 +1,86 @@
+import { defaultUsers } from '@/constants';
+import {
+  createUser,
+  deleteUser,
+  expectDeleteUserSuccess,
+  expectUserNotFoundError,
+  expectFindUserByUsernameSuccess,
+  expectLoginSuccess,
+  expectUnauthorizedResponseForInvalidAuthorizationHeader,
+  expectUnauthorizedResponseForMissingAuthorizationHeader,
+  expectUnauthorizedResponseWhenUserHasInsufficientPermission,
+  expectUserCreationSuccess,
+  findUserByUsername,
+  login,
+  verifyAccount,
+  expectBadRequestResponseForValidationError,
+} from '@/utils/test';
+import { GetUser } from '../user.validation';
+import mongoose from 'mongoose';
+
+const newUser = {
+  username: 'username',
+  email: 'validemail@example.com',
+  password: 'ValidPassword123!',
+  confirmPassword: 'ValidPassword123!',
+};
+
+describe('Soft Delete User', () => {
+  let authorizationHeader: string;
+  let userToDelete: GetUser;
+
+  beforeAll(async () => {
+    const loginResponse = await login(defaultUsers);
+    expectLoginSuccess(loginResponse);
+    authorizationHeader = `Bearer ${loginResponse.header['authorization']}`;
+
+    const userResponse = await createUser(newUser, authorizationHeader);
+    expectUserCreationSuccess(userResponse, newUser);
+
+    const foundUserRes = await findUserByUsername(newUser.username);
+    expectFindUserByUsernameSuccess(foundUserRes, newUser);
+
+    userToDelete = foundUserRes.body.user;
+  });
+
+  it('should return 401 for missing authorization header', async () => {
+    const response = await deleteUser(userToDelete.id, '');
+    expectUnauthorizedResponseForMissingAuthorizationHeader(response);
+  });
+
+  it('should return 401 for invalid authorization header', async () => {
+    const response = await deleteUser(userToDelete.id, 'invalid');
+    expectUnauthorizedResponseForInvalidAuthorizationHeader(response);
+  });
+
+  it('should return 400 for invalid user id', async () => {
+    const response = await deleteUser('invalid', authorizationHeader);
+    expectBadRequestResponseForValidationError(response);
+  });
+
+  it('should return 404 for user not found', async () => {
+    const response = await deleteUser(new mongoose.Types.ObjectId().toHexString(), authorizationHeader);
+    expectUserNotFoundError(response);
+  });
+
+  it('should return 403 for unauthorized user', async () => {
+    const unAuthorizedUser = { ...newUser, username: 'unauthorized', email: 'unauthorized@gmail.com' };
+
+    const createUserRes = await createUser(unAuthorizedUser, authorizationHeader);
+    expectUserCreationSuccess(createUserRes, unAuthorizedUser);
+
+    await verifyAccount(unAuthorizedUser);
+
+    const loginResponse = await login(unAuthorizedUser);
+    expectLoginSuccess(loginResponse);
+    const header = `Bearer ${loginResponse.header['authorization']}`;
+
+    const deleteUserRes = await deleteUser(userToDelete.id, header);
+    expectUnauthorizedResponseWhenUserHasInsufficientPermission(deleteUserRes);
+  });
+
+  it('should soft delete user', async () => {
+    const response = await deleteUser(userToDelete.id, authorizationHeader);
+    expectDeleteUserSuccess(response);
+  });
+});

--- a/src/api/v1/user/__test__/user.test.ts
+++ b/src/api/v1/user/__test__/user.test.ts
@@ -1,9 +1,22 @@
 import supertest from 'supertest';
 import { app } from '@/app';
 import { success } from '../user.constant';
-import { ErrorTypeEnum, STATUS_CODES, errorMap } from '@/constants';
+import { ErrorTypeEnum, STATUS_CODES, defaultUsers, errorMap } from '@/constants';
+import {
+  createUser,
+  expectFindUserByUsernameNotFound,
+  expectFindUserByUsernameSuccess,
+  expectLoginSuccess,
+  expectUnauthorizedResponseForInvalidAuthorizationHeader,
+  expectUnauthorizedResponseForMissingAuthorizationHeader,
+  expectUnauthorizedResponseWhenUserHasInsufficientPermission,
+  expectUserCreationSuccess,
+  findUserByUsername,
+  login,
+  verifyAccount,
+} from '@/utils/test';
 
-const VALID_CREDENTIALS = {
+const newUser = {
   username: 'username',
   email: 'validemail@example.com',
   password: 'ValidPassword123!',
@@ -11,29 +24,47 @@ const VALID_CREDENTIALS = {
 };
 
 describe('User Test', () => {
+  let authorizationHeader: string;
+  beforeAll(async () => {
+    const loginResponse = await login(defaultUsers);
+    expectLoginSuccess(loginResponse);
+    authorizationHeader = `Bearer ${loginResponse.header['authorization']}`;
+  });
+
+  it('should return 401 for missing authorization header', async () => {
+    const response = await createUser(newUser, '');
+    expectUnauthorizedResponseForMissingAuthorizationHeader(response);
+  });
+
+  it('should return 401 for invalid authorization header', async () => {
+    const response = await createUser(newUser, 'invalid');
+    expectUnauthorizedResponseForInvalidAuthorizationHeader(response);
+  });
+
+  it('should not create a new user without create-user permission', async () => {
+    const unAuthorizedUser = { ...newUser, username: 'unauthorized', email: 'unauthorized@gmail.com' };
+
+    const response = await createUser(unAuthorizedUser, authorizationHeader);
+    expectUserCreationSuccess(response, unAuthorizedUser);
+
+    await verifyAccount(unAuthorizedUser);
+
+    const loginResponse = await login(unAuthorizedUser);
+    expectLoginSuccess(loginResponse);
+    const header = `Bearer ${loginResponse.header['authorization']}`;
+
+    const newUserRes = await createUser(newUser, header);
+    expectUnauthorizedResponseWhenUserHasInsufficientPermission(newUserRes);
+  });
+
   it('should create a new user with valid credentials', async () => {
-    const response = await supertest(app).post('/api/v1/users').send(VALID_CREDENTIALS);
-
-    const { statusCode, body } = response;
-
-    expect(statusCode).toBe(STATUS_CODES.CREATED);
-
-    expect(body).toMatchObject({
-      message: success.USER_CREATED_SUCCESSFULLY,
-      user: {
-        id: expect.any(String),
-        email: VALID_CREDENTIALS.email,
-        username: VALID_CREDENTIALS.username,
-      },
-    });
-
-    expect(body.user).not.toHaveProperty('password');
-    expect(body.user).not.toHaveProperty('confirmPassword');
+    const response = await createUser(newUser, authorizationHeader);
+    expectUserCreationSuccess(response, newUser);
   });
 
   it('should respond with 409 for duplicate email', async () => {
     const errorObject = errorMap[ErrorTypeEnum.enum.EMAIL_ALREADY_EXISTS];
-    const response = await supertest(app).post('/api/v1/users').send(VALID_CREDENTIALS);
+    const response = await createUser(newUser, authorizationHeader);
 
     expect(response.statusCode).toBe(STATUS_CODES.CONFLICT);
     expect(response.body.message).toBe(errorObject.body.message);
@@ -42,48 +73,20 @@ describe('User Test', () => {
 
   it('should respond with 409 for duplicate username', async () => {
     const errorObject = errorMap[ErrorTypeEnum.enum.USER_NAME_ALREADY_EXISTS];
-    const response = await supertest(app)
-      .post('/api/v1/users')
-      .send({
-        ...VALID_CREDENTIALS,
-        email: 'new@gmail.com',
-      });
+    const response = await createUser({ ...newUser, email: 'new@gmail.com' }, authorizationHeader);
     expect(response.statusCode).toBe(STATUS_CODES.CONFLICT);
     expect(response.body.message).toBe(errorObject.body.message);
     expect(response.body.code).toBe(errorObject.body.code);
   });
 
   it('should find user by username', async () => {
-    const response = await supertest(app).get(`/api/v1/users/${VALID_CREDENTIALS.username}`);
-
-    const { statusCode, body } = response;
-
-    expect(statusCode).toBe(STATUS_CODES.OK);
-
-    expect(body).toMatchObject({
-      message: success.USER_FETCHED_SUCCESSFULLY,
-      user: {
-        id: expect.any(String),
-        email: VALID_CREDENTIALS.email,
-        username: VALID_CREDENTIALS.username,
-      },
-    });
-
-    expect(body.user).not.toHaveProperty('password');
-    expect(body.user).not.toHaveProperty('confirmPassword');
+    const response = await findUserByUsername(newUser.username);
+    expectFindUserByUsernameSuccess(response, newUser);
   });
 
   it('should respond with 404 for user not found', async () => {
-    const errorObject = errorMap[ErrorTypeEnum.enum.USER_NOT_FOUND];
-    const response = await supertest(app).get('/api/v1/users/invalidUsername');
-
-    expect(response.statusCode).toBe(STATUS_CODES.NOT_FOUND);
-
-    expect(response.body).toMatchObject({
-      message: errorObject.body.message,
-      code: errorObject.body.code,
-      status: 'failed',
-    });
+    const response = await findUserByUsername('invalidUsername');
+    expectFindUserByUsernameNotFound(response);
   });
 
   it('should fetch all users', async () => {
@@ -105,7 +108,7 @@ describe('User Test', () => {
   });
 
   it('should soft delete user', async () => {
-    const userResponse = await supertest(app).get(`/api/v1/users/${VALID_CREDENTIALS.username}`);
+    const userResponse = await supertest(app).get(`/api/v1/users/${newUser.username}`);
     const response = await supertest(app).delete(`/api/v1/users/${userResponse.body.user.id}`);
 
     const { statusCode, body } = response;
@@ -116,8 +119,8 @@ describe('User Test', () => {
       message: success.USER_DELETED_SUCCESSFULLY,
       user: {
         id: expect.any(String),
-        email: VALID_CREDENTIALS.email,
-        username: VALID_CREDENTIALS.username,
+        email: newUser.email,
+        username: newUser.username,
       },
     });
 
@@ -133,7 +136,7 @@ describe('User Test', () => {
       confirmPassword: 'ValidPassword123!',
     };
 
-    const userResponse = await supertest(app).post('/api/v1/users').send(newUser);
+    const userResponse = await createUser(newUser, authorizationHeader);
 
     const response = await supertest(app).patch(`/api/v1/users/${userResponse.body.user.id}/restore`);
 

--- a/src/api/v1/user/__test__/user.test.ts
+++ b/src/api/v1/user/__test__/user.test.ts
@@ -4,7 +4,7 @@ import { success } from '../user.constant';
 import { ErrorTypeEnum, STATUS_CODES, defaultUsers, errorMap } from '@/constants';
 import {
   createUser,
-  expectFindUserByUsernameNotFound,
+  expectUserNotFoundError,
   expectFindUserByUsernameSuccess,
   expectLoginSuccess,
   expectUnauthorizedResponseForInvalidAuthorizationHeader,
@@ -86,7 +86,7 @@ describe('User Test', () => {
 
   it('should respond with 404 for user not found', async () => {
     const response = await findUserByUsername('invalidUsername');
-    expectFindUserByUsernameNotFound(response);
+    expectUserNotFoundError(response);
   });
 
   it('should fetch all users', async () => {
@@ -105,27 +105,6 @@ describe('User Test', () => {
       expect(body.users[0]).not.toHaveProperty('password');
       expect(body.users[0]).not.toHaveProperty('confirmPassword');
     }
-  });
-
-  it('should soft delete user', async () => {
-    const userResponse = await supertest(app).get(`/api/v1/users/${newUser.username}`);
-    const response = await supertest(app).delete(`/api/v1/users/${userResponse.body.user.id}`);
-
-    const { statusCode, body } = response;
-
-    expect(statusCode).toBe(STATUS_CODES.OK);
-
-    expect(body).toMatchObject({
-      message: success.USER_DELETED_SUCCESSFULLY,
-      user: {
-        id: expect.any(String),
-        email: newUser.email,
-        username: newUser.username,
-      },
-    });
-
-    expect(body.user).not.toHaveProperty('password');
-    expect(body.user).not.toHaveProperty('confirmPassword');
   });
 
   it('should restore deleted user', async () => {

--- a/src/api/v1/user/__test__/user.test.ts
+++ b/src/api/v1/user/__test__/user.test.ts
@@ -106,33 +106,4 @@ describe('User Test', () => {
       expect(body.users[0]).not.toHaveProperty('confirmPassword');
     }
   });
-
-  it('should restore deleted user', async () => {
-    const newUser = {
-      username: 'username1',
-      email: 'validemail1@example.com',
-      password: 'ValidPassword123!',
-      confirmPassword: 'ValidPassword123!',
-    };
-
-    const userResponse = await createUser(newUser, authorizationHeader);
-
-    const response = await supertest(app).patch(`/api/v1/users/${userResponse.body.user.id}/restore`);
-
-    const { statusCode, body } = response;
-
-    expect(statusCode).toBe(STATUS_CODES.OK);
-
-    expect(body).toMatchObject({
-      message: success.USER_RESTORED_SUCCESSFULLY,
-      user: {
-        id: expect.any(String),
-        email: newUser.email,
-        username: newUser.username,
-      },
-    });
-
-    expect(body.user).not.toHaveProperty('password');
-    expect(body.user).not.toHaveProperty('confirmPassword');
-  });
 });

--- a/src/api/v1/user/user.route.ts
+++ b/src/api/v1/user/user.route.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { createUser, getAllUsers, getUserByUsername, softDeleteUser, restoreUser } from './user.controller';
+import { checkPermission, validateAccessToken } from '@/middlewares';
 
 const router = Router();
 
-router.post('/users', createUser);
+router.post('/users', validateAccessToken, checkPermission(['create-users']), createUser);
 router.get('/users', getAllUsers);
 router.get('/users/:username', getUserByUsername);
 router.delete('/users/:userId', softDeleteUser);

--- a/src/api/v1/user/user.route.ts
+++ b/src/api/v1/user/user.route.ts
@@ -8,6 +8,6 @@ router.post('/users', validateAccessToken, checkPermission(['create-users']), cr
 router.get('/users', getAllUsers);
 router.get('/users/:username', getUserByUsername);
 router.delete('/users/:userId', validateAccessToken, checkPermission(['delete-users']), softDeleteUser);
-router.patch('/users/:userId/restore', restoreUser);
+router.patch('/users/:userId/restore', validateAccessToken, checkPermission(['restore-users']), restoreUser);
 
 export { router as userRoutes };

--- a/src/api/v1/user/user.route.ts
+++ b/src/api/v1/user/user.route.ts
@@ -7,7 +7,7 @@ const router = Router();
 router.post('/users', validateAccessToken, checkPermission(['create-users']), createUser);
 router.get('/users', getAllUsers);
 router.get('/users/:username', getUserByUsername);
-router.delete('/users/:userId', softDeleteUser);
+router.delete('/users/:userId', validateAccessToken, checkPermission(['delete-users']), softDeleteUser);
 router.patch('/users/:userId/restore', restoreUser);
 
 export { router as userRoutes };

--- a/src/utils/test/auth.utils.ts
+++ b/src/utils/test/auth.utils.ts
@@ -4,7 +4,8 @@ import { Login } from '@/api/v1/auth/auth.validation';
 import { STATUS_CODES } from '@/constants';
 import { success } from '@/api/v1/auth/auth.constant';
 import { expectOTPRequestSuccess, expectOTPVerificationSuccess, requestOTP, retrieveOTP, verifyOTP } from './otp.utils';
-import { expectUserRetrievalSuccess, retrieveUser } from './user.utils';
+import { expectFindUserByUsernameSuccess, findUserByUsername } from './user.utils';
+import { CreateUser } from '../../api/v1/user/user.validation';
 
 export async function login(loginData: Login): Promise<Response> {
   return supertest(app).post('/api/v1/auth/login').send(loginData);
@@ -77,14 +78,15 @@ export const expectRenewTokenSuccess = (response: Response) => {
   });
 };
 
-export const verifyAccount = async ({ email, username }: { email: string; username: string }) => {
+export const verifyAccount = async (user: CreateUser) => {
   // Step 1: Request OTP
+  const { email, username } = user;
   const otpResponse = await requestOTP(email);
   expectOTPRequestSuccess(otpResponse);
 
   // Step 2: Retrieve User from database
-  const userResponse = await retrieveUser(username);
-  expectUserRetrievalSuccess(userResponse);
+  const userResponse = await findUserByUsername(username);
+  expectFindUserByUsernameSuccess(userResponse, user);
 
   // Step 2: Retrieve OTP from database
   const otpData = await retrieveOTP(userResponse.body.user.id);

--- a/src/utils/test/user.utils.ts
+++ b/src/utils/test/user.utils.ts
@@ -89,3 +89,22 @@ export function expectDeleteUserSuccess(response: Response): void {
   expect(body.user).not.toHaveProperty('password');
   expect(body.user).not.toHaveProperty('confirmPassword');
 }
+
+export async function restoreUser(userId: string, authorizationHeader: string): Promise<Response> {
+  return supertest(app).patch(`/api/v1/users/${userId}/restore`).set('authorization', authorizationHeader);
+}
+
+export function expectRestoreUserSuccess(response: Response): void {
+  expect(response).toBeDefined();
+  const { statusCode, body } = response;
+
+  expect(statusCode).toBe(STATUS_CODES.OK);
+
+  expect(body).toMatchObject({
+    message: success.USER_RESTORED_SUCCESSFULLY,
+    user: { id: expect.any(String) },
+  });
+
+  expect(body.user).not.toHaveProperty('password');
+  expect(body.user).not.toHaveProperty('confirmPassword');
+}

--- a/src/utils/test/user.utils.ts
+++ b/src/utils/test/user.utils.ts
@@ -4,6 +4,17 @@ import { errorMap, ErrorTypeEnum, STATUS_CODES } from '@/constants';
 import { CreateUser } from '../../api/v1/user/user.validation';
 import { success } from '../../api/v1/user/user.constant';
 
+export const expectBadRequestResponseForValidationError = (response: Response): void => {
+  const errorObject = errorMap[ErrorTypeEnum.enum.VALIDATION_ERROR];
+
+  expect(response).toBeDefined();
+  expect(response.statusCode).toBe(STATUS_CODES.BAD_REQUEST);
+  expect(response.body).toMatchObject({
+    message: errorObject.body.message,
+    code: errorObject.body.code,
+  });
+};
+
 export async function createUser(user: CreateUser, authorizationHeader: string): Promise<Response> {
   return supertest(app).post('/api/v1/users').send(user).set('authorization', authorizationHeader);
 }
@@ -30,7 +41,7 @@ export async function findUserByUsername(username: string): Promise<Response> {
   return supertest(app).get(`/api/v1/users/${username}`);
 }
 
-export function expectFindUserByUsernameNotFound(response: Response): void {
+export function expectUserNotFoundError(response: Response): void {
   const errorObject = errorMap[ErrorTypeEnum.enum.USER_NOT_FOUND];
 
   expect(response).toBeDefined();
@@ -54,6 +65,25 @@ export function expectFindUserByUsernameSuccess(response: Response, user: Create
       email: user.email,
       username: user.username,
     },
+  });
+
+  expect(body.user).not.toHaveProperty('password');
+  expect(body.user).not.toHaveProperty('confirmPassword');
+}
+
+export async function deleteUser(userId: string, authorizationHeader: string): Promise<Response> {
+  return supertest(app).delete(`/api/v1/users/${userId}`).set('authorization', authorizationHeader);
+}
+
+export function expectDeleteUserSuccess(response: Response): void {
+  expect(response).toBeDefined();
+  const { statusCode, body } = response;
+
+  expect(statusCode).toBe(STATUS_CODES.OK);
+
+  expect(body).toMatchObject({
+    message: success.USER_DELETED_SUCCESSFULLY,
+    user: { id: expect.any(String) },
   });
 
   expect(body.user).not.toHaveProperty('password');

--- a/src/utils/test/user.utils.ts
+++ b/src/utils/test/user.utils.ts
@@ -1,11 +1,61 @@
 import supertest, { Response } from 'supertest';
 import { app } from '@/app';
-import { STATUS_CODES } from '@/constants';
+import { errorMap, ErrorTypeEnum, STATUS_CODES } from '@/constants';
+import { CreateUser } from '../../api/v1/user/user.validation';
+import { success } from '../../api/v1/user/user.constant';
 
-export async function retrieveUser(username: string): Promise<Response> {
+export async function createUser(user: CreateUser, authorizationHeader: string): Promise<Response> {
+  return supertest(app).post('/api/v1/users').send(user).set('authorization', authorizationHeader);
+}
+
+export function expectUserCreationSuccess(response: Response, user: CreateUser): void {
+  expect(response).toBeDefined();
+  const { statusCode, body } = response;
+
+  expect(statusCode).toBe(STATUS_CODES.CREATED);
+  expect(body).toMatchObject({
+    message: success.USER_CREATED_SUCCESSFULLY,
+    user: {
+      id: expect.any(String),
+      email: user.email,
+      username: user.username,
+    },
+  });
+
+  expect(body.user).not.toHaveProperty('password');
+  expect(body.user).not.toHaveProperty('confirmPassword');
+}
+
+export async function findUserByUsername(username: string): Promise<Response> {
   return supertest(app).get(`/api/v1/users/${username}`);
 }
 
-export function expectUserRetrievalSuccess(response: Response): void {
-  expect(response.statusCode).toBe(STATUS_CODES.OK);
+export function expectFindUserByUsernameNotFound(response: Response): void {
+  const errorObject = errorMap[ErrorTypeEnum.enum.USER_NOT_FOUND];
+
+  expect(response).toBeDefined();
+  expect(response.statusCode).toBe(STATUS_CODES.NOT_FOUND);
+  expect(response.body).toMatchObject({
+    message: errorObject.body.message,
+    code: errorObject.body.code,
+    status: 'failed',
+  });
+}
+
+export function expectFindUserByUsernameSuccess(response: Response, user: CreateUser): void {
+  expect(response).toBeDefined();
+  const { statusCode, body } = response;
+
+  expect(statusCode).toBe(STATUS_CODES.OK);
+  expect(body).toMatchObject({
+    message: success.USER_FETCHED_SUCCESSFULLY,
+    user: {
+      id: expect.any(String),
+      email: user.email,
+      username: user.username,
+    },
+  });
+
+  expect(body.user).not.toHaveProperty('password');
+  expect(body.user).not.toHaveProperty('confirmPassword');
 }


### PR DESCRIPTION
- **Implement Authentication Middleware**: Apply the `validateAccessToken` middleware to the user deletion, creation, and restoration routes. This ensures that only authenticated (logged-in) users can perform these operations.
  
- **Enforce Permission Checks**: Utilize the `checkPermission` middleware to restrict actions based on user permissions. Only users with the specific permissions—`delete-users`, `create-users`, and `restore-users`—can execute delete, create, and restore operations, respectively.
  
- **Update and Expand Test Coverage**:
  - **Modify Existing Tests**: Update current test cases to reflect the new authentication and permission requirements.
  - **Add New Tests**: Develop additional tests to verify that the middleware correctly enforces authentication and permission checks for all relevant user actions.