### PR TITLE
feat(security): Implement global rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "date-fns": "^3.6.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       express:
         specifier: ^4.19.2
         version: 4.19.2
+      express-rate-limit:
+        specifier: ^7.4.0
+        version: 7.4.0(express@4.19.2)
       helmet:
         specifier: ^7.1.0
         version: 7.1.0
@@ -1197,6 +1200,12 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-rate-limit@7.4.0:
+    resolution: {integrity: sha512-v1204w3cXu5gCDmAvgvzI6qjzZzoMWKnyVDk3ACgfswTQLYiGen+r8w0VnXnGMmzEN/g8fwIQ4JrFFd4ZP6ssg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: 4 || 5 || ^5.0.0-beta.1
 
   express@4.19.2:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
@@ -3992,6 +4001,10 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express-rate-limit@7.4.0(express@4.19.2):
+    dependencies:
+      express: 4.19.2
 
   express@4.19.2:
     dependencies:

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,8 +3,9 @@ import { pinoHttp } from 'pino-http';
 import helmet from 'helmet';
 import cors from 'cors';
 import passport from 'passport';
+import rateLimit from 'express-rate-limit';
 
-import { envConstants, ErrorTypeEnum } from '@/constants';
+import { envConstants, ErrorTypeEnum, FIFTEEN_MINUTES_IN_MS } from '@/constants';
 import { logger } from '@/utils';
 import { addAxiosHeadersMiddleware, errorHandler } from '@/middlewares';
 import { routes } from '@/routes';
@@ -55,6 +56,16 @@ if (NODE_ENV !== 'test') {
     return;
   });
 }
+
+const globalLimiter = rateLimit({
+  windowMs: FIFTEEN_MINUTES_IN_MS, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  message: 'Too many requests from this IP, please try again after 15 minutes',
+});
+
+app.use(globalLimiter);
 
 app.use(express.json());
 app.use(passport.initialize());

--- a/src/constants/magicNumbers.constant.ts
+++ b/src/constants/magicNumbers.constant.ts
@@ -1,1 +1,2 @@
 export const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
+export const FIFTEEN_MINUTES_IN_MS = 1000 * 60 * 15;


### PR DESCRIPTION
- Add express-rate-limit package
- Configure global rate limiter in app.ts
- Set limit to 100 requests per 15 minutes
- Enable standard rate limit headers
- Disable legacy X-RateLimit headers

This commit enhances API security by introducing a global rate limiting mechanism. It helps prevent abuse, mitigates DoS attacks, and ensures fair usage of our API.

Rate limit details:
- 100 requests per IP address
- 15-minute window
- Returns 429 Too Many Requests when limit is exceeded

Headers added:
- RateLimit-Limit
- RateLimit-Remaining
- RateLimit-Reset
- RateLimit-Policy