### PR TITLE
Feat/83 update api response

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
   verbose: true,
   preset: "ts-jest",
   moduleFileExtensions: ["js", "ts", "json", "node"],
+  testTimeout: 10000,
   modulePathIgnorePatterns: ["<rootDir>/build"],
   transformIgnorePatterns: ["node_modules/(?!(jest-)?ts-jest)"],
   roots: ["<rootDir>/src"],

--- a/src/api/v1/auth/__test__/reset-password.test.ts
+++ b/src/api/v1/auth/__test__/reset-password.test.ts
@@ -74,7 +74,7 @@ describe("Reset Password", () => {
 
       const userResponse = await findUserByUsername(user.username);
       expectFindUserByUsernameSuccess(userResponse, user);
-      const userDetails: GetUser = userResponse.body.user;
+      const userDetails: GetUser = userResponse.body.data.user;
 
       const otpData = await retrieveOTP(userDetails.id, "sendForgetPasswordOTP");
       verifiedOTPResponse = await verifyOTP(otpData, user.email);
@@ -82,7 +82,7 @@ describe("Reset Password", () => {
     });
 
     it("should reset password successfully", async () => {
-      const { token } = verifiedOTPResponse.body;
+      const { token } = verifiedOTPResponse.body.data;
 
       const res = await resetPassword({
         token,

--- a/src/api/v1/auth/auth.controller.ts
+++ b/src/api/v1/auth/auth.controller.ts
@@ -42,7 +42,7 @@ export class AuthController {
         response: res,
         message: success.LOGGED_IN_SUCCESSFULLY,
         statusCode: STATUS_CODES.OK,
-        payload: { userId },
+        data: { userId },
       });
     } catch (error) {
       next(error);

--- a/src/api/v1/auth/auth.validation.ts
+++ b/src/api/v1/auth/auth.validation.ts
@@ -36,7 +36,7 @@ export const jwtActionTokenSchema = z.object({
 });
 
 export const sendOtpSchema = z.object({
-  payload: userSchema.shape.email,
+  data: userSchema.shape.email,
   eventType: z.enum(["signUp", "resetPassword", "sendEmailVerificationOTP"]),
 });
 

--- a/src/api/v1/otp/otp.controller.ts
+++ b/src/api/v1/otp/otp.controller.ts
@@ -37,7 +37,7 @@ export class OtpController {
         response: res,
         message: message,
         statusCode: STATUS_CODES.OK,
-        payload: { token },
+        data: { token },
       });
     } catch (error) {
       next(error);

--- a/src/api/v1/otp/otp.service.ts
+++ b/src/api/v1/otp/otp.service.ts
@@ -28,7 +28,7 @@ export class OtpService {
       notificationService.sendEmail({
         to: user.email,
         eventType: otpType,
-        payload: { otp },
+        data: { otp },
       });
     }
 
@@ -41,7 +41,7 @@ export class OtpService {
       notificationService.sendEmail({
         to: user.email,
         eventType: otpType,
-        payload: { otp },
+        data: { otp },
       });
     }
 

--- a/src/api/v1/otp/otp.validation.ts
+++ b/src/api/v1/otp/otp.validation.ts
@@ -55,7 +55,7 @@ const validateOtpEvent = (data: BaseSchema) => {
 };
 
 export const otpEvent = baseSchema.refine(validateOtpEvent, {
-  message: "Invalid payload for the given optType",
+  message: "Invalid data for the given optType",
   path: ["optType"],
 });
 
@@ -64,7 +64,7 @@ export const otpVerifyEvent = baseSchema
     otp,
   })
   .refine(validateOtpEvent, {
-    message: "Invalid payload for the given optType",
+    message: "Invalid data for the given optType",
     path: ["optType"],
   });
 

--- a/src/api/v1/permission/permission.controller.ts
+++ b/src/api/v1/permission/permission.controller.ts
@@ -12,7 +12,7 @@ export const createPermission = async (req: Request, res: Response, next: NextFu
     sendResponse({
       response: res,
       message: success.PERMISSION_CREATED_SUCCESSFULLY,
-      payload: {
+      data: {
         permission: createdPermission,
       },
       statusCode: STATUS_CODES.CREATED,
@@ -28,7 +28,7 @@ export const getPermissions = async (_: Request, res: Response, next: NextFuncti
     sendResponse({
       response: res,
       message: success.PERMISSION_FETCHED_SUCCESSFULLY,
-      payload: {
+      data: {
         permissions,
       },
       statusCode: STATUS_CODES.OK,

--- a/src/api/v1/profile/__test__/profle.test.ts
+++ b/src/api/v1/profile/__test__/profle.test.ts
@@ -25,7 +25,7 @@ describe("Profile Service", () => {
   beforeAll(async () => {
     const loginResponse = await login(defaultUsers);
     expectLoginSuccess(loginResponse);
-    loggedInUserId = loginResponse.body.userId;
+    loggedInUserId = loginResponse.body.data.userId;
     authorizationHeader = `Bearer ${loginResponse.header["authorization"]}`;
   });
 

--- a/src/api/v1/profile/profile.controller.ts
+++ b/src/api/v1/profile/profile.controller.ts
@@ -15,7 +15,7 @@ export class ProfileController {
       sendResponse({
         response: res,
         message: success.PROFILE_UPDATED_SUCCESSFULLY,
-        payload: profile,
+        data: profile,
         statusCode: 200,
       });
     } catch (error) {

--- a/src/api/v1/profile/profile.dal.ts
+++ b/src/api/v1/profile/profile.dal.ts
@@ -2,12 +2,12 @@ import { ProfileDataModel } from "./profile.modal";
 import { ProfileData } from "./profile.validation";
 
 interface IProfileDataDal {
-  upSertProfileData(payload: ProfileData): Promise<ProfileData>;
+  upSertProfileData(data: ProfileData): Promise<ProfileData>;
 }
 
 export class ProfileDataDAL implements IProfileDataDal {
-  async upSertProfileData(payload: ProfileData): Promise<ProfileData> {
-    return await ProfileDataModel.findOneAndUpdate({ userId: payload.userId }, payload, {
+  async upSertProfileData(data: ProfileData): Promise<ProfileData> {
+    return await ProfileDataModel.findOneAndUpdate({ userId: data.userId }, data, {
       upsert: true,
       new: true,
     });

--- a/src/api/v1/profile/profile.service.ts
+++ b/src/api/v1/profile/profile.service.ts
@@ -9,8 +9,8 @@ export class ProfileService {
     this.profileDataDal = new ProfileDataDAL();
   }
 
-  upSertProfileData = async (payload: ProfileData) => {
-    const profileData = validateProfileSchema(payload);
+  upSertProfileData = async (data: ProfileData) => {
+    const profileData = validateProfileSchema(data);
 
     const updateProfileData = await this.profileDataDal.upSertProfileData(profileData);
     return ProfileDto(updateProfileData).getProfile();

--- a/src/api/v1/role/role.controller.ts
+++ b/src/api/v1/role/role.controller.ts
@@ -12,7 +12,7 @@ export const createRole = async (req: Request, res: Response, next: NextFunction
     sendResponse({
       response: res,
       message: success.ROLE_CREATED_SUCCESSFULLY,
-      payload: {
+      data: {
         role,
       },
       statusCode: STATUS_CODES.CREATED,
@@ -28,7 +28,7 @@ export const getRoles = async (_: Request, res: Response, next: NextFunction) =>
     sendResponse({
       response: res,
       message: success.ROLES_FETCHED_SUCCESSFULLY,
-      payload: {
+      data: {
         roles,
       },
       statusCode: STATUS_CODES.OK,

--- a/src/api/v1/rolePermission/__test__/role-permission.test.ts
+++ b/src/api/v1/rolePermission/__test__/role-permission.test.ts
@@ -44,8 +44,8 @@ describe("Role Permission Test", () => {
     expectCreatePermissionSuccess(permissionRes, VALID_PERMISSION);
 
     const rolePermission = {
-      roleId: roleResponse.body.role.id,
-      permissionId: permissionRes.body.permission.id,
+      roleId: roleResponse.body.data.role.id,
+      permissionId: permissionRes.body.data.permission.id,
     };
 
     const response = await createRolePermissionRequest(rolePermission, authorizationHeader);

--- a/src/api/v1/rolePermission/role-permission.controller.ts
+++ b/src/api/v1/rolePermission/role-permission.controller.ts
@@ -12,7 +12,7 @@ export const createRolePermission = async (req: Request, res: Response, next: Ne
     sendResponse({
       response: res,
       message: success.ROLE_PERMISSION_CREATED_SUCCESSFULLY,
-      payload: {
+      data: {
         rolePermission,
       },
       statusCode: STATUS_CODES.CREATED,

--- a/src/api/v1/token/token.dal.ts
+++ b/src/api/v1/token/token.dal.ts
@@ -2,17 +2,17 @@ import { TokenModel } from "./token.model";
 import { CreateToken, Token, UpdateToken } from "./token.validation";
 
 interface ITokenDal {
-  saveToken(payload: Token): Promise<CreateToken>;
+  saveToken(data: Token): Promise<CreateToken>;
   getToken(token: string): Promise<Token | null>;
   getTokensByUserId(userId: string): Promise<Token[] | null>;
-  updateToken(tokenId: string, payload: Token): Promise<Token | null>;
+  updateToken(tokenId: string, data: Token): Promise<Token | null>;
   deleteToken(tokenId: string): Promise<Token | null>;
   replaceTokenForUser(createTokenSchema: CreateToken): Promise<Token | null>;
 }
 
 export class TokenDAL implements ITokenDal {
-  async saveToken(payload: CreateToken): Promise<Token> {
-    return await TokenModel.create(payload);
+  async saveToken(data: CreateToken): Promise<Token> {
+    return await TokenModel.create(data);
   }
 
   async getToken(token: string): Promise<Token | null> {
@@ -23,8 +23,8 @@ export class TokenDAL implements ITokenDal {
     return await TokenModel.find({ userId });
   }
 
-  async updateToken(tokenId: string, payload: UpdateToken): Promise<Token | null> {
-    return await TokenModel.findByIdAndUpdate(tokenId, payload, { new: true });
+  async updateToken(tokenId: string, data: UpdateToken): Promise<Token | null> {
+    return await TokenModel.findByIdAndUpdate(tokenId, data, { new: true });
   }
 
   async deleteToken(tokenId: string): Promise<Token | null> {

--- a/src/api/v1/token/token.service.ts
+++ b/src/api/v1/token/token.service.ts
@@ -16,7 +16,7 @@ export class TokenService {
   async createActionToken(userId: string, action: TokenAction) {
     const token = generateTokenForAction({ userId, action });
 
-    const tokenPayload: CreateToken = {
+    const tokendata: CreateToken = {
       userId,
       action,
       token,
@@ -24,7 +24,7 @@ export class TokenService {
       expiryTime: new Date(Date.now() + FIVE_MINUTES_IN_MS),
     };
 
-    await this.tokenDAL.replaceTokenForUser(tokenPayload);
+    await this.tokenDAL.replaceTokenForUser(tokendata);
     return token;
   }
 

--- a/src/api/v1/user/__test__/restore-user.test.ts
+++ b/src/api/v1/user/__test__/restore-user.test.ts
@@ -42,7 +42,7 @@ describe("Restore User", () => {
     const foundUserRes = await findUserByUsername(newUser.username);
     expectFindUserByUsernameSuccess(foundUserRes, newUser);
 
-    userToDelete = foundUserRes.body.user;
+    userToDelete = foundUserRes.body.data.user;
   });
 
   it("should return 401 for missing authorization header", async () => {

--- a/src/api/v1/user/__test__/soft-delete-user.test.ts
+++ b/src/api/v1/user/__test__/soft-delete-user.test.ts
@@ -42,7 +42,7 @@ describe("Soft Delete User", () => {
     const foundUserRes = await findUserByUsername(newUser.username);
     expectFindUserByUsernameSuccess(foundUserRes, newUser);
 
-    userToDelete = foundUserRes.body.user;
+    userToDelete = foundUserRes.body.data.user;
   });
 
   it("should return 401 for missing authorization header", async () => {

--- a/src/api/v1/user/__test__/user.test.ts
+++ b/src/api/v1/user/__test__/user.test.ts
@@ -104,12 +104,14 @@ describe("User Test", () => {
 
     expect(body).toMatchObject({
       message: success.USER_FETCHED_SUCCESSFULLY,
-      users: expect.any(Array),
+      data: {
+        users: expect.any(Array),
+      },
     });
 
-    if (body.users.length > 0) {
-      expect(body.users[0]).not.toHaveProperty("password");
-      expect(body.users[0]).not.toHaveProperty("confirmPassword");
+    if (body.data.users.length > 0) {
+      expect(body.data.users[0]).not.toHaveProperty("password");
+      expect(body.data.users[0]).not.toHaveProperty("confirmPassword");
     }
   });
 });

--- a/src/api/v1/user/user.controller.ts
+++ b/src/api/v1/user/user.controller.ts
@@ -12,7 +12,7 @@ export const createUser = async (req: Request, res: Response, next: NextFunction
     sendResponse({
       response: res,
       message: success.USER_CREATED_SUCCESSFULLY,
-      payload: {
+      data: {
         user,
       },
       statusCode: STATUS_CODES.CREATED,
@@ -28,7 +28,7 @@ export const getAllUsers = async (_: Request, res: Response, next: NextFunction)
     sendResponse({
       response: res,
       message: success.USER_FETCHED_SUCCESSFULLY,
-      payload: {
+      data: {
         users,
       },
       statusCode: STATUS_CODES.OK,
@@ -44,7 +44,7 @@ export const getUserByUsername = async (req: Request, res: Response, next: NextF
     sendResponse({
       response: res,
       message: success.USER_FETCHED_SUCCESSFULLY,
-      payload: {
+      data: {
         user,
       },
       statusCode: STATUS_CODES.OK,
@@ -60,7 +60,7 @@ export const softDeleteUser = async (req: Request, res: Response, next: NextFunc
     sendResponse({
       response: res,
       message: success.USER_DELETED_SUCCESSFULLY,
-      payload: {
+      data: {
         user,
       },
       statusCode: STATUS_CODES.OK,
@@ -76,7 +76,7 @@ export const restoreUser = async (req: Request, res: Response, next: NextFunctio
     sendResponse({
       response: res,
       message: success.USER_RESTORED_SUCCESSFULLY,
-      payload: {
+      data: {
         user,
       },
       statusCode: STATUS_CODES.OK,

--- a/src/api/v1/userRole/__test__/user-role.test.ts
+++ b/src/api/v1/userRole/__test__/user-role.test.ts
@@ -24,7 +24,7 @@ describe("User Role Test", () => {
   beforeAll(async () => {
     const loginResponse = await login(defaultUsers);
     expectLoginSuccess(loginResponse);
-    loggedInUserId = loginResponse.body.userId;
+    loggedInUserId = loginResponse.body.data.userId;
     authorizationHeader = `Bearer ${loginResponse.header["authorization"]}`;
   });
 
@@ -33,7 +33,7 @@ describe("User Role Test", () => {
     expectCreateRoleSuccess(response, VALID_ROLE);
 
     const userRole = {
-      roleId: response.body.role.id,
+      roleId: response.body.data.role.id,
       userId: loggedInUserId,
     };
 

--- a/src/api/v1/userRole/user-role.controller.ts
+++ b/src/api/v1/userRole/user-role.controller.ts
@@ -12,7 +12,7 @@ export const createUserRole = async (req: Request, res: Response, next: NextFunc
     sendResponse({
       response: res,
       message: success.USER_ROLE_CREATED_SUCCESSFULLY,
-      payload: {
+      data: {
         userRole,
       },
       statusCode: STATUS_CODES.CREATED,

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,7 @@ if (NODE_ENV !== "test") {
   app.use(helmet());
 
   // Apply CORS middleware with a whitelist (adjust origins as needed)
-  const allowedOrigins = ["http://localhost:3000"];
+  const allowedOrigins = ["http://localhost:3000", "http://192.168.1.233:3000"];
   const allowedPathsWithoutOrigin = ["/api/v1/auth/google/callback", "/api/v1/auth/google"];
 
   const corsOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,16 @@ import { setupInitialRolesAndPermissions, setupInitialUserRole } from "./script"
 import { startServer } from "./server";
 
 (async () => {
-  await connectDB();
-  if (!envConstants.INITIAL_SETUP_DONE) {
-    await setupInitialRolesAndPermissions();
-    await setupInitialUserRole();
+  try {
+    await connectDB();
+    if (!envConstants.INITIAL_SETUP_DONE) {
+      await setupInitialRolesAndPermissions();
+      await setupInitialUserRole();
+    }
+    await startServer(envConstants.APP_PORT);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("Failed to setup initial data:", error);
+    process.exit(1);
   }
 })();
-
-startServer(envConstants.APP_PORT);

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -7,10 +7,10 @@ beforeAll(async () => {
   await connectDB();
   await setupInitialRolesAndPermissions();
   await setupInitialUserRole();
-  startServer(envConstants.APP_PORT);
+  await startServer(envConstants.APP_PORT);
 });
 
 afterAll(async () => {
   await disconnectDB();
-  stopServer();
+  await stopServer();
 });

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -13,10 +13,8 @@ export const errorHandler = (err: Error, _: Request, res: Response, next: NextFu
       statusCode: errorObj.httpStatusCode,
       message: errorObj.body.message,
       errorDetails: err,
-      payload: {
-        code: errorObj.body.code,
-        errors: err.issues,
-      },
+      code: errorObj.body.code,
+      errors: err.issues,
     });
     return next();
   }
@@ -28,9 +26,7 @@ export const errorHandler = (err: Error, _: Request, res: Response, next: NextFu
     statusCode: errorObj.httpStatusCode,
     message: errorObj.body.message,
     errorDetails: err,
-    payload: {
-      code: errorObj.body.code,
-    },
+    code: errorObj.body.code,
   });
   next();
 };

--- a/src/services/notification.validation.ts
+++ b/src/services/notification.validation.ts
@@ -29,12 +29,12 @@ export const emailValidator = z
 
 export const otpValidator = z.string().length(6, "OTP must be exactly 6 characters");
 
-//  Specific payload schemas
-const emailVerificationOTPPayload = z.object({
+//  Specific data schemas
+const emailVerificationOTPdata = z.object({
   otp: otpValidator,
 });
 
-const passwordResetOTPPayload = z.object({
+const passwordResetOTPdata = z.object({
   otp: otpValidator,
 });
 
@@ -44,20 +44,20 @@ const emailNotification = z.discriminatedUnion("eventType", [
     to: emailValidator,
     eventType: z.literal("sendEmailVerificationOTP"),
     subject: z.string().optional(),
-    payload: emailVerificationOTPPayload,
+    data: emailVerificationOTPdata,
   }),
   z.object({
     to: emailValidator,
     eventType: z.literal("sendForgetPasswordOTP"),
     subject: z.string().optional(),
-    payload: passwordResetOTPPayload,
+    data: passwordResetOTPdata,
   }),
   z.object({
     to: emailValidator,
     eventType: z.literal("sendPasswordChangeConfirmation"),
     subject: z.string().optional(),
   }),
-  // ... Add other event types and their corresponding payloads ...
+  // ... Add other event types and their corresponding datas ...
 ]);
 
 export const validateEmailNotification = (data: EmailNotification) => {
@@ -67,7 +67,7 @@ export const validateEmailNotification = (data: EmailNotification) => {
     if (error instanceof z.ZodError) {
       // Customize error messages
       const customErrors = error.issues.map((issue) => {
-        if (issue.code === "invalid_type" && issue.path.includes("payload")) {
+        if (issue.code === "invalid_type" && issue.path.includes("data")) {
           const fieldName = issue.path[issue.path.length - 1];
           return {
             ...issue,

--- a/src/utils/__test__/jwt.test.ts
+++ b/src/utils/__test__/jwt.test.ts
@@ -8,7 +8,7 @@ jest.mock("jsonwebtoken", () => ({
 }));
 
 describe("Jwt token", () => {
-  const mockPayload: JwtAccessToken = {
+  const mockdata: JwtAccessToken = {
     userId: "123",
   };
 
@@ -17,7 +17,7 @@ describe("Jwt token", () => {
   });
 
   it("should generate an access token", () => {
-    const token = generateAccessToken(mockPayload);
+    const token = generateAccessToken(mockdata);
     expect(token).toBeDefined();
   });
 

--- a/src/utils/__test__/send-response.test.ts
+++ b/src/utils/__test__/send-response.test.ts
@@ -3,7 +3,7 @@ import { Response } from "express";
 import { SendResponse, sendResponse } from "@/utils";
 
 describe("sendResponse", () => {
-  it("should return a successful response with the correct payload", () => {
+  it("should return a successful response with the correct data", () => {
     const mockResponse: Response = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn(),
@@ -13,7 +13,7 @@ describe("sendResponse", () => {
       response: mockResponse,
       statusCode: 200,
       message: "Success!",
-      payload: { someData: "Hello, World!" },
+      data: { someData: "Hello, World!" },
     };
 
     sendResponse(mockData);
@@ -21,7 +21,7 @@ describe("sendResponse", () => {
     expect(mockResponse.status).toHaveBeenCalledWith(200);
     expect(mockResponse.json).toHaveBeenCalledWith({
       message: "Success!",
-      someData: "Hello, World!",
+      data: { someData: "Hello, World!" },
       status: "success",
     });
   });

--- a/src/utils/jwt.util.ts
+++ b/src/utils/jwt.util.ts
@@ -19,19 +19,19 @@ export const tokenSecrets = {
   action: JWT_TOKEN_FOR_ACTION_SECRET,
 };
 
-export const generateAccessToken = (payload: JwtAccessToken) => {
-  const validPayload = jwtAccessTokenSchema.parse(payload);
-  return jwt.sign(validPayload, JWT_ACCESS_SECRET, { expiresIn: "1h" });
+export const generateAccessToken = (data: JwtAccessToken) => {
+  const validdata = jwtAccessTokenSchema.parse(data);
+  return jwt.sign(validdata, JWT_ACCESS_SECRET, { expiresIn: "1h" });
 };
 
-export const generateRefreshToken = (payload: JwtRefreshToken) => {
-  const validPayload = jwtRefreshTokenSchema.parse(payload);
-  return jwt.sign(validPayload, JWT_REFRESH_SECRET, { expiresIn: "7d" });
+export const generateRefreshToken = (data: JwtRefreshToken) => {
+  const validdata = jwtRefreshTokenSchema.parse(data);
+  return jwt.sign(validdata, JWT_REFRESH_SECRET, { expiresIn: "7d" });
 };
 
-export const generateTokenForAction = (payload: JwtActionToken) => {
-  const validPayload = jwtActionTokenSchema.parse(payload);
-  return jwt.sign(validPayload, JWT_TOKEN_FOR_ACTION_SECRET, {
+export const generateTokenForAction = (data: JwtActionToken) => {
+  const validdata = jwtActionTokenSchema.parse(data);
+  return jwt.sign(validdata, JWT_TOKEN_FOR_ACTION_SECRET, {
     expiresIn: "5m",
   });
 };

--- a/src/utils/test/auth.utils.ts
+++ b/src/utils/test/auth.utils.ts
@@ -99,7 +99,7 @@ export const verifyAccount = async (user: CreateUser) => {
   expectFindUserByUsernameSuccess(userResponse, user);
 
   // Step 2: Retrieve OTP from database
-  const otpData = await retrieveOTP(userResponse.body.user.id, "sendEmailVerificationOTP");
+  const otpData = await retrieveOTP(userResponse.body.data.user.id, "sendEmailVerificationOTP");
 
   // Step 3: Verify OTP
   const verifyResponse = await verifyOTP(otpData, email);

--- a/src/utils/test/permission.utils.ts
+++ b/src/utils/test/permission.utils.ts
@@ -16,11 +16,13 @@ export const expectCreatePermissionSuccess = (response: Response, permission: cr
 
   expect(body).toMatchObject({
     message: success.PERMISSION_CREATED_SUCCESSFULLY,
-    permission: {
-      id: expect.any(String),
-      name: permission.name,
-      description: permission.description,
-      category: permission.category,
+    data: {
+      permission: {
+        id: expect.any(String),
+        name: permission.name,
+        description: permission.description,
+        category: permission.category,
+      },
     },
   });
 };
@@ -37,6 +39,8 @@ export const expectGetPermissionsSuccess = (response: Response): void => {
   expect(statusCode).toBe(STATUS_CODES.OK);
   expect(body).toMatchObject({
     message: success.PERMISSION_FETCHED_SUCCESSFULLY,
-    permissions: expect.any(Array),
+    data: {
+      permissions: expect.any(Array),
+    },
   });
 };

--- a/src/utils/test/profile.utils.ts
+++ b/src/utils/test/profile.utils.ts
@@ -4,28 +4,25 @@ import { CreateProfileData, ProfileData, success } from "@/api/v1/profile";
 import { app } from "@/app";
 import { STATUS_CODES } from "@/constants";
 
-export const upSertProfileData = async (payload: CreateProfileData, authorizationHeader: string) => {
-  return await supertest(app).put("/api/v1/profile").set("authorization", authorizationHeader).send(payload);
+export const upSertProfileData = async (data: CreateProfileData, authorizationHeader: string) => {
+  return await supertest(app).put("/api/v1/profile").set("authorization", authorizationHeader).send(data);
 };
 
-export const expectProfileData = (response: Response, payload: ProfileData) => {
+export const expectProfileData = (response: Response, data: ProfileData) => {
   expect(response).toBeDefined();
   expect(response.statusCode).toBe(STATUS_CODES.OK);
+  expect(response.body.message).toBe(success.PROFILE_UPDATED_SUCCESSFULLY);
+  expect(response.body.status).toBe("success");
 
-  const expectedBody: Partial<ProfileData> & {
-    message: string;
-    status: string;
-  } = {
-    message: success.PROFILE_UPDATED_SUCCESSFULLY,
-    status: "success",
-    userId: payload.userId,
+  const expectedBody: Partial<ProfileData> & {} = {
+    userId: data.userId,
   };
 
-  if (payload.avatar != null) expectedBody.avatar = payload.avatar;
-  if (payload.bio != null) expectedBody.bio = payload.bio;
-  if (payload.phoneNumber != null) expectedBody.phoneNumber = payload.phoneNumber;
-  if (payload.address) expectedBody.address = payload.address;
-  if (payload.socialLinks) expectedBody.socialLinks = payload.socialLinks;
+  if (data.avatar != null) expectedBody.avatar = data.avatar;
+  if (data.bio != null) expectedBody.bio = data.bio;
+  if (data.phoneNumber != null) expectedBody.phoneNumber = data.phoneNumber;
+  if (data.address) expectedBody.address = data.address;
+  if (data.socialLinks) expectedBody.socialLinks = data.socialLinks;
 
-  expect(response.body).toMatchObject(expectedBody);
+  expect(response.body.data).toMatchObject(expectedBody);
 };

--- a/src/utils/test/role-permission.utils.ts
+++ b/src/utils/test/role-permission.utils.ts
@@ -21,9 +21,11 @@ export const expectCreateRolePermissionSuccess = (response: Response, rolePermis
 
   expect(body).toMatchObject({
     message: success.ROLE_PERMISSION_CREATED_SUCCESSFULLY,
-    rolePermission: {
-      roleId: rolePermission.roleId,
-      permissionId: rolePermission.permissionId,
+    data: {
+      rolePermission: {
+        roleId: rolePermission.roleId,
+        permissionId: rolePermission.permissionId,
+      },
     },
   });
 };

--- a/src/utils/test/role.utils.ts
+++ b/src/utils/test/role.utils.ts
@@ -18,10 +18,12 @@ export const expectCreateRoleSuccess = (response: Response, { name, description 
 
   expect(body).toMatchObject({
     message: success.ROLE_CREATED_SUCCESSFULLY,
-    role: {
-      id: expect.any(String),
-      name,
-      description,
+    data: {
+      role: {
+        id: expect.any(String),
+        name,
+        description,
+      },
     },
   });
 };
@@ -38,6 +40,8 @@ export const expectGetRolesSuccess = (response: Response): void => {
   expect(statusCode).toBe(STATUS_CODES.OK);
   expect(body).toMatchObject({
     message: success.ROLES_FETCHED_SUCCESSFULLY,
-    roles: expect.any(Array),
+    data: {
+      roles: expect.any(Array),
+    },
   });
 };

--- a/src/utils/test/user-role.utils.ts
+++ b/src/utils/test/user-role.utils.ts
@@ -18,9 +18,11 @@ export const expectCreateUserRoleSuccess = (response: Response, { roleId, userId
 
   expect(body).toMatchObject({
     message: success.USER_ROLE_CREATED_SUCCESSFULLY,
-    userRole: {
-      roleId,
-      userId,
+    data: {
+      userRole: {
+        roleId,
+        userId,
+      },
     },
   });
 };

--- a/src/utils/test/user.utils.ts
+++ b/src/utils/test/user.utils.ts
@@ -28,15 +28,17 @@ export const expectUserCreationSuccess = (response: Response, user: CreateUser):
   expect(statusCode).toBe(STATUS_CODES.CREATED);
   expect(body).toMatchObject({
     message: success.USER_CREATED_SUCCESSFULLY,
-    user: {
-      id: expect.any(String),
-      email: user.email,
-      username: user.username,
+    data: {
+      user: {
+        id: expect.any(String),
+        email: user.email,
+        username: user.username,
+      },
     },
   });
 
-  expect(body.user).not.toHaveProperty("password");
-  expect(body.user).not.toHaveProperty("confirmPassword");
+  expect(body.data.user).not.toHaveProperty("password");
+  expect(body.data.user).not.toHaveProperty("confirmPassword");
 };
 
 export const findUserByUsername = async (username: string): Promise<Response> => {
@@ -62,15 +64,17 @@ export const expectFindUserByUsernameSuccess = (response: Response, user: Create
   expect(statusCode).toBe(STATUS_CODES.OK);
   expect(body).toMatchObject({
     message: success.USER_FETCHED_SUCCESSFULLY,
-    user: {
-      id: expect.any(String),
-      email: user.email,
-      username: user.username,
+    data: {
+      user: {
+        id: expect.any(String),
+        email: user.email,
+        username: user.username,
+      },
     },
   });
 
-  expect(body.user).not.toHaveProperty("password");
-  expect(body.user).not.toHaveProperty("confirmPassword");
+  expect(body.data.user).not.toHaveProperty("password");
+  expect(body.data.user).not.toHaveProperty("confirmPassword");
 };
 
 export const deleteUser = async (userId: string, authorizationHeader: string): Promise<Response> => {
@@ -85,11 +89,11 @@ export const expectDeleteUserSuccess = (response: Response): void => {
 
   expect(body).toMatchObject({
     message: success.USER_DELETED_SUCCESSFULLY,
-    user: { id: expect.any(String) },
+    data: { user: { id: expect.any(String) } },
   });
 
-  expect(body.user).not.toHaveProperty("password");
-  expect(body.user).not.toHaveProperty("confirmPassword");
+  expect(body.data.user).not.toHaveProperty("password");
+  expect(body.data.user).not.toHaveProperty("confirmPassword");
 };
 
 export const restoreUser = async (userId: string, authorizationHeader: string): Promise<Response> => {
@@ -104,9 +108,9 @@ export const expectRestoreUserSuccess = (response: Response): void => {
 
   expect(body).toMatchObject({
     message: success.USER_RESTORED_SUCCESSFULLY,
-    user: { id: expect.any(String) },
+    data: { user: { id: expect.any(String) } },
   });
 
-  expect(body.user).not.toHaveProperty("password");
-  expect(body.user).not.toHaveProperty("confirmPassword");
+  expect(body.data.user).not.toHaveProperty("password");
+  expect(body.data.user).not.toHaveProperty("confirmPassword");
 };


### PR DESCRIPTION
feat: namespace API response payload under `data`

- Refactored the `sendResponse` function to wrap `payload` under a `data` key.
- Updated the response structure to improve consistency and prevent key conflicts.
- Adjusted error handling to ensure compatibility with the new structure.
- Added necessary checks for development vs production environments.
- Updated tests to align with the modified response format.

BREAKING CHANGE: API responses now return the `payload` under a `data` key. Update any client-side implementations or integrations that rely on the old response format.
