### PR TITLE
Replace MongooseObjectId with ObjectId and update types package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the User Service will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2025-10-06
+
+### Added
+
+- Replace MongooseObjectId with ObjectId and update @ansospace/types package ([#141](https://github.com/ansopedia/user-service/issues/141))
+
 ## [1.3.0] - 2025-10-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "user service for ansopedia",
   "main": "dist/index.js",
   "type": "module",
@@ -33,7 +33,7 @@
   "author": "ansopedia",
   "license": "ISC",
   "dependencies": {
-    "@ansospace/types": "0.3.3",
+    "@ansospace/types": "0.3.8",
     "axios": "1.12.2",
     "bcrypt": "6.0.0",
     "cors": "2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ansospace/types':
-        specifier: 0.3.3
-        version: 0.3.3
+        specifier: 0.3.8
+        version: 0.3.8
       axios:
         specifier: 1.12.2
         version: 1.12.2
@@ -171,8 +171,8 @@ importers:
 
 packages:
 
-  '@ansospace/types@0.3.3':
-    resolution: {integrity: sha512-uMAH3g7eOF1DPpVXkfqsjsTB+dOshdjkj0eC9oJdS+33GnWocuAx39cW5E4DhN6YoXdUHYS/XUSeILLgFGuQZA==}
+  '@ansospace/types@0.3.8':
+    resolution: {integrity: sha512-bf7XA7cLToWIYPVa50C+KgYPk6YV/4kHJvZL679FN8NyAFDYZVlgqg5cdbuGen4j2EhgvVu7vMrqTrr5kuUrHA==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -1818,39 +1818,8 @@ packages:
       socks:
         optional: true
 
-  mongodb@6.20.0:
-    resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
-    engines: {node: '>=16.20.1'}
-    peerDependencies:
-      '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
-      gcp-metadata: ^5.2.0
-      kerberos: ^2.0.1
-      mongodb-client-encryption: '>=6.0.0 <7'
-      snappy: ^7.3.2
-      socks: ^2.7.1
-    peerDependenciesMeta:
-      '@aws-sdk/credential-providers':
-        optional: true
-      '@mongodb-js/zstd':
-        optional: true
-      gcp-metadata:
-        optional: true
-      kerberos:
-        optional: true
-      mongodb-client-encryption:
-        optional: true
-      snappy:
-        optional: true
-      socks:
-        optional: true
-
   mongoose@8.18.1:
     resolution: {integrity: sha512-K0RfrUXXufqNRZZjvAGdyjydB91SnbWxlwFYi5t7zN2DxVWFD3c6puia0/7xfBwZm6RCpYOVdYFlRFpoDWiC+w==}
-    engines: {node: '>=16.20.1'}
-
-  mongoose@8.19.0:
-    resolution: {integrity: sha512-Z4iRiBkC7aR7a/rxQxtUAUBasFdiXkBuv3EY4NwkRbs92xKA4pwzi1Q4D+odFBe+ChahMNAYg2JP+7tWzZM0sQ==}
     engines: {node: '>=16.20.1'}
 
   morgan@1.10.1:
@@ -2629,19 +2598,10 @@ packages:
 
 snapshots:
 
-  '@ansospace/types@0.3.3':
+  '@ansospace/types@0.3.8':
     dependencies:
-      mongoose: 8.19.0
+      bson: 6.10.4
       zod: 3.25.76
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-providers'
-      - '@mongodb-js/zstd'
-      - gcp-metadata
-      - kerberos
-      - mongodb-client-encryption
-      - snappy
-      - socks
-      - supports-color
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -4288,36 +4248,11 @@ snapshots:
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
 
-  mongodb@6.20.0:
-    dependencies:
-      '@mongodb-js/saslprep': 1.3.0
-      bson: 6.10.4
-      mongodb-connection-string-url: 3.0.2
-
   mongoose@8.18.1:
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3
       mongodb: 6.18.0
-      mpath: 0.9.0
-      mquery: 5.0.0
-      ms: 2.1.3
-      sift: 17.1.3
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-providers'
-      - '@mongodb-js/zstd'
-      - gcp-metadata
-      - kerberos
-      - mongodb-client-encryption
-      - snappy
-      - socks
-      - supports-color
-
-  mongoose@8.19.0:
-    dependencies:
-      bson: 6.10.4
-      kareem: 2.6.3
-      mongodb: 6.20.0
       mpath: 0.9.0
       mquery: 5.0.0
       ms: 2.1.3

--- a/src/api/v1/auth/auth.controller.ts
+++ b/src/api/v1/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import {
   type AuthToken,
+  type LoginResponse,
   type SignUpResponse,
   emailSchema,
   loginSchema,
@@ -56,7 +57,7 @@ export class AuthController {
 
     AuthController.setAuthTokenHeaders(res, accessToken, refreshToken, deviceId);
 
-    sendResponse({
+    sendResponse<LoginResponse>({
       response: res,
       message: success.LOGGED_IN_SUCCESSFULLY,
       statusCode: STATUS_CODES.OK,

--- a/src/api/v1/auth/auth.service.ts
+++ b/src/api/v1/auth/auth.service.ts
@@ -6,7 +6,7 @@ import {
   type DeviceInfo,
   type Email,
   type Login,
-  type MongooseObjectId,
+  type ObjectId,
   type RefreshTokenPayload,
   type RegisterSchema,
   type ResetPassword,
@@ -30,7 +30,7 @@ import { SessionDAL } from "../session/session.dal.js";
 import { success } from "./auth.constant.js";
 
 interface GenerateTokenParams {
-  userId: MongooseObjectId;
+  userId: ObjectId;
   deviceInfo: DeviceInfo;
   deviceId: DeviceId;
   tokenVersion: number;
@@ -153,7 +153,7 @@ export class AuthService {
     await new SessionDAL().updateSessionByUserAndDevice(userId, deviceId, { isActive: false });
   }
 
-  public static async logoutAll(userId: MongooseObjectId): Promise<{ modifiedCount?: number }> {
+  public static async logoutAll(userId: ObjectId): Promise<{ modifiedCount?: number }> {
     // Increment tokenVersion for all sessions and deactivate them
     const sessions = await new SessionDAL().getSessionsByUserId(userId);
 
@@ -173,7 +173,7 @@ export class AuthService {
     return { modifiedCount: sessions.length };
   }
 
-  public static async logoutOthers(deviceId: string, userId: MongooseObjectId): Promise<{ modifiedCount?: number }> {
+  public static async logoutOthers(deviceId: string, userId: ObjectId): Promise<{ modifiedCount?: number }> {
     // Increment tokenVersion for all sessions except current and deactivate them
     const sessions = await new SessionDAL().getSessionsByUserId(userId);
 
@@ -197,7 +197,7 @@ export class AuthService {
     return { modifiedCount };
   }
 
-  public static async getSessions(userId: MongooseObjectId) {
+  public static async getSessions(userId: ObjectId) {
     return await new SessionDAL().getActiveSessionsByUserId(userId);
   }
 

--- a/src/api/v1/otp/otp.dal.ts
+++ b/src/api/v1/otp/otp.dal.ts
@@ -1,4 +1,4 @@
-import type { GetOtp, MongooseObjectId, OtpRecord, SaveOtp } from "@ansospace/types";
+import type { GetOtp, ObjectId, OtpRecord, SaveOtp } from "@ansospace/types";
 
 import { OtpModel } from "./otp.model.js";
 
@@ -12,11 +12,11 @@ export class OtpDAL {
     return await OtpModel.find(otpSchema);
   }
 
-  static async deleteOtp(otpId: MongooseObjectId) {
+  static async deleteOtp(otpId: ObjectId) {
     return await OtpModel.findByIdAndDelete(otpId);
   }
 
-  static async deleteOtpByUserId(userId: MongooseObjectId) {
+  static async deleteOtpByUserId(userId: ObjectId) {
     return await OtpModel.deleteMany({ userId });
   }
 

--- a/src/api/v1/profile/__test__/profle.test.ts
+++ b/src/api/v1/profile/__test__/profle.test.ts
@@ -1,4 +1,4 @@
-import type { CreateProfileData, MongooseObjectId } from "@ansospace/types";
+import type { CreateProfileData, ObjectId } from "@ansospace/types";
 
 import { defaultUsers } from "@/constants";
 import {
@@ -25,7 +25,7 @@ const profileData: CreateProfileData = {
 
 describe("Profile Service", () => {
   let authorizationHeader: string;
-  let loggedInUserId: MongooseObjectId;
+  let loggedInUserId: ObjectId;
 
   beforeAll(async () => {
     const loginResponse = await login(defaultUsers);

--- a/src/api/v1/profile/profile.dal.ts
+++ b/src/api/v1/profile/profile.dal.ts
@@ -1,11 +1,11 @@
-import type { MongooseObjectId, ProfileData } from "@ansospace/types";
+import type { ObjectId, ProfileData } from "@ansospace/types";
 
 import { ProfileDataModel } from "./profile.model.js";
 
 interface IProfileDataDal {
   upSertProfileData(data: ProfileData): Promise<ProfileData>;
-  getProfileData(userId: MongooseObjectId): Promise<ProfileData | null>;
-  toggleProfileVisibility(userId: MongooseObjectId, isPublic: boolean): Promise<ProfileData | null>;
+  getProfileData(userId: ObjectId): Promise<ProfileData | null>;
+  toggleProfileVisibility(userId: ObjectId, isPublic: boolean): Promise<ProfileData | null>;
 }
 
 export class ProfileDataDAL implements IProfileDataDal {
@@ -16,11 +16,11 @@ export class ProfileDataDAL implements IProfileDataDal {
     });
   }
 
-  async getProfileData(userId: MongooseObjectId): Promise<ProfileData | null> {
+  async getProfileData(userId: ObjectId): Promise<ProfileData | null> {
     return await ProfileDataModel.findOne({ userId });
   }
 
-  async toggleProfileVisibility(userId: MongooseObjectId, isPublic: boolean): Promise<ProfileData | null> {
+  async toggleProfileVisibility(userId: ObjectId, isPublic: boolean): Promise<ProfileData | null> {
     return await ProfileDataModel.findOneAndUpdate({ userId }, { isPublic }, { new: true });
   }
 }

--- a/src/api/v1/profile/profile.service.ts
+++ b/src/api/v1/profile/profile.service.ts
@@ -1,4 +1,4 @@
-import { type MongooseObjectId, type ProfileData, validateProfileSchema } from "@ansospace/types";
+import { type ObjectId, type ProfileData, validateProfileSchema } from "@ansospace/types";
 
 import { ErrorTypeEnum } from "@/constants";
 
@@ -16,11 +16,11 @@ export class ProfileService {
     return await this.profileDataDal.upSertProfileData(profileData);
   };
 
-  getProfileData = async (userId: MongooseObjectId): Promise<ProfileData | null> => {
+  getProfileData = async (userId: ObjectId): Promise<ProfileData | null> => {
     return await this.profileDataDal.getProfileData(userId);
   };
 
-  toggleProfileVisibility = async (userId: MongooseObjectId, isPublic: boolean): Promise<ProfileData> => {
+  toggleProfileVisibility = async (userId: ObjectId, isPublic: boolean): Promise<ProfileData> => {
     const profile = await this.profileDataDal.toggleProfileVisibility(userId, isPublic);
 
     if (!profile) {

--- a/src/api/v1/role/role.dal.ts
+++ b/src/api/v1/role/role.dal.ts
@@ -1,4 +1,4 @@
-import type { CreateRole, MongooseObjectId, Role } from "@ansospace/types";
+import type { CreateRole, ObjectId, Role } from "@ansospace/types";
 
 import { RoleModel } from "./role.model.js";
 
@@ -23,11 +23,11 @@ export class RoleDAL {
     return await RoleModel.findOne({ name });
   }
 
-  static async softDeleteRole(roleId: MongooseObjectId): Promise<Role | null> {
+  static async softDeleteRole(roleId: ObjectId): Promise<Role | null> {
     return await RoleModel.findByIdAndUpdate(roleId, { isDeleted: true }, { new: true });
   }
 
-  static async restoreRole(roleId: MongooseObjectId): Promise<Role | null> {
+  static async restoreRole(roleId: ObjectId): Promise<Role | null> {
     return await RoleModel.findByIdAndUpdate(roleId, { isDeleted: false }, { new: true });
   }
 }

--- a/src/api/v1/session/session.dal.ts
+++ b/src/api/v1/session/session.dal.ts
@@ -1,4 +1,4 @@
-import type { ObjectId, Session } from "@ansospace/types";
+import type { DeviceId, ObjectId, Session } from "@ansospace/types";
 
 import { generateRefreshToken } from "@/utils";
 
@@ -14,9 +14,9 @@ interface ISessionDal {
   getActiveSessionsSafe(userId: ObjectId): Promise<SessionSafe[]>; // Safe version without sensitive data
   insertSession(session: Omit<Session, "refreshToken" | "createdAt" | "updatedAt" | "isActive">): Promise<Session>;
   updateSession(sessionId: ObjectId): Promise<Session | null>;
-  updateSessionByUserAndDevice(userId: ObjectId, deviceId: string, update: Partial<Session>): Promise<Session | null>;
+  updateSessionByUserAndDevice(userId: ObjectId, deviceId: DeviceId, update: Partial<Session>): Promise<Session | null>;
   deleteSession(sessionId: ObjectId): Promise<void>;
-  deleteSessionByUserAndDevice(userId: ObjectId, deviceId: string): Promise<void>;
+  deleteSessionByUserAndDevice(userId: ObjectId, deviceId: DeviceId): Promise<void>;
   deleteAllExceptSessionId(userId: ObjectId, sessionId: ObjectId): Promise<{ deletedCount?: number }>;
   deleteAllSession(userId: ObjectId): Promise<{ deletedCount?: number }>;
   deactivateAllExceptSessionId(userId: ObjectId, sessionId: ObjectId): Promise<{ modifiedCount?: number }>;
@@ -35,7 +35,7 @@ export class SessionDAL implements ISessionDal {
 
   async updateSessionByUserAndDevice(
     userId: ObjectId,
-    deviceId: string,
+    deviceId: DeviceId,
     update: Partial<Session>
   ): Promise<Session | null> {
     return await sessionModel.findOneAndUpdate({ userId, deviceId }, update, { new: true });
@@ -85,7 +85,7 @@ export class SessionDAL implements ISessionDal {
     await sessionModel.findByIdAndDelete(sessionId);
   }
 
-  async deleteSessionByUserAndDevice(userId: ObjectId, deviceId: string): Promise<void> {
+  async deleteSessionByUserAndDevice(userId: ObjectId, deviceId: DeviceId): Promise<void> {
     await sessionModel.deleteOne({ userId, deviceId });
   }
 

--- a/src/api/v1/session/session.dal.ts
+++ b/src/api/v1/session/session.dal.ts
@@ -1,4 +1,4 @@
-import type { MongooseObjectId, Session } from "@ansospace/types";
+import type { ObjectId, Session } from "@ansospace/types";
 
 import { generateRefreshToken } from "@/utils";
 
@@ -8,63 +8,53 @@ import sessionModel from "./session.model.js";
 export type SessionSafe = Omit<Session, "refreshToken">;
 
 interface ISessionDal {
-  getSessionById(sessionId: MongooseObjectId): Promise<Session | null>;
-  getSessionsByUserId(userId: MongooseObjectId): Promise<Session[]>;
-  getActiveSessionsByUserId(userId: MongooseObjectId): Promise<Session[]>;
-  getActiveSessionsSafe(userId: MongooseObjectId): Promise<SessionSafe[]>; // Safe version without sensitive data
+  getSessionById(sessionId: ObjectId): Promise<Session | null>;
+  getSessionsByUserId(userId: ObjectId): Promise<Session[]>;
+  getActiveSessionsByUserId(userId: ObjectId): Promise<Session[]>;
+  getActiveSessionsSafe(userId: ObjectId): Promise<SessionSafe[]>; // Safe version without sensitive data
   insertSession(session: Omit<Session, "refreshToken" | "createdAt" | "updatedAt" | "isActive">): Promise<Session>;
-  updateSession(sessionId: MongooseObjectId): Promise<Session | null>;
-  updateSessionByUserAndDevice(
-    userId: MongooseObjectId,
-    deviceId: string,
-    update: Partial<Session>
-  ): Promise<Session | null>;
-  deleteSession(sessionId: MongooseObjectId): Promise<void>;
-  deleteSessionByUserAndDevice(userId: MongooseObjectId, deviceId: string): Promise<void>;
-  deleteAllExceptSessionId(userId: MongooseObjectId, sessionId: MongooseObjectId): Promise<{ deletedCount?: number }>;
-  deleteAllSession(userId: MongooseObjectId): Promise<{ deletedCount?: number }>;
-  deactivateAllExceptSessionId(
-    userId: MongooseObjectId,
-    sessionId: MongooseObjectId
-  ): Promise<{ modifiedCount?: number }>;
-  deactivateAllSession(userId: MongooseObjectId): Promise<{ modifiedCount?: number }>;
+  updateSession(sessionId: ObjectId): Promise<Session | null>;
+  updateSessionByUserAndDevice(userId: ObjectId, deviceId: string, update: Partial<Session>): Promise<Session | null>;
+  deleteSession(sessionId: ObjectId): Promise<void>;
+  deleteSessionByUserAndDevice(userId: ObjectId, deviceId: string): Promise<void>;
+  deleteAllExceptSessionId(userId: ObjectId, sessionId: ObjectId): Promise<{ deletedCount?: number }>;
+  deleteAllSession(userId: ObjectId): Promise<{ deletedCount?: number }>;
+  deactivateAllExceptSessionId(userId: ObjectId, sessionId: ObjectId): Promise<{ modifiedCount?: number }>;
+  deactivateAllSession(userId: ObjectId): Promise<{ modifiedCount?: number }>;
 }
 
 export class SessionDAL implements ISessionDal {
-  async getActiveSessionsByUserId(userId: MongooseObjectId): Promise<Session[]> {
+  async getActiveSessionsByUserId(userId: ObjectId): Promise<Session[]> {
     // Select only safe fields, exclude sensitive data like refreshToken
     return await sessionModel.find({ userId, isActive: true }).select("-refreshToken"); // Exclude refreshToken using select notation
   }
 
-  async getActiveSessionsSafe(userId: MongooseObjectId): Promise<SessionSafe[]> {
+  async getActiveSessionsSafe(userId: ObjectId): Promise<SessionSafe[]> {
     return await sessionModel.find({ userId, isActive: true }).select("-refreshToken"); // Exclude refreshToken using select notation
   }
 
   async updateSessionByUserAndDevice(
-    userId: MongooseObjectId,
+    userId: ObjectId,
     deviceId: string,
     update: Partial<Session>
   ): Promise<Session | null> {
     return await sessionModel.findOneAndUpdate({ userId, deviceId }, update, { new: true });
   }
 
-  async deactivateAllExceptSessionId(
-    userId: MongooseObjectId,
-    sessionId: MongooseObjectId
-  ): Promise<{ modifiedCount?: number }> {
+  async deactivateAllExceptSessionId(userId: ObjectId, sessionId: ObjectId): Promise<{ modifiedCount?: number }> {
     const result = await sessionModel.updateMany({ userId, _id: { $ne: sessionId } }, { isActive: false });
     return { modifiedCount: result.modifiedCount };
   }
 
-  async deactivateAllSession(userId: MongooseObjectId): Promise<{ modifiedCount?: number }> {
+  async deactivateAllSession(userId: ObjectId): Promise<{ modifiedCount?: number }> {
     const result = await sessionModel.updateMany({ userId }, { isActive: false });
     return { modifiedCount: result.modifiedCount };
   }
-  async getSessionById(sessionId: MongooseObjectId): Promise<Session | null> {
+  async getSessionById(sessionId: ObjectId): Promise<Session | null> {
     return await sessionModel.findById(sessionId);
   }
 
-  async getSessionsByUserId(userId: MongooseObjectId): Promise<Session[]> {
+  async getSessionsByUserId(userId: ObjectId): Promise<Session[]> {
     return await sessionModel.find({ userId });
   }
 
@@ -77,7 +67,7 @@ export class SessionDAL implements ISessionDal {
     return await newSession.save();
   }
 
-  async updateSession(sessionId: MongooseObjectId): Promise<Session | null> {
+  async updateSession(sessionId: ObjectId): Promise<Session | null> {
     const refreshToken = generateRefreshToken({ sessionId });
 
     return await sessionModel.findByIdAndUpdate(
@@ -91,22 +81,19 @@ export class SessionDAL implements ISessionDal {
     );
   }
 
-  async deleteSession(sessionId: MongooseObjectId): Promise<void> {
+  async deleteSession(sessionId: ObjectId): Promise<void> {
     await sessionModel.findByIdAndDelete(sessionId);
   }
 
-  async deleteSessionByUserAndDevice(userId: MongooseObjectId, deviceId: string): Promise<void> {
+  async deleteSessionByUserAndDevice(userId: ObjectId, deviceId: string): Promise<void> {
     await sessionModel.deleteOne({ userId, deviceId });
   }
 
-  async deleteAllExceptSessionId(
-    userId: MongooseObjectId,
-    sessionId: MongooseObjectId
-  ): Promise<{ deletedCount?: number }> {
+  async deleteAllExceptSessionId(userId: ObjectId, sessionId: ObjectId): Promise<{ deletedCount?: number }> {
     return await sessionModel.deleteMany({ userId, _id: { $ne: sessionId } });
   }
 
-  async deleteAllSession(userId: MongooseObjectId): Promise<{ deletedCount?: number }> {
+  async deleteAllSession(userId: ObjectId): Promise<{ deletedCount?: number }> {
     return await sessionModel.deleteMany({ userId });
   }
 }

--- a/src/api/v1/token/token.dal.ts
+++ b/src/api/v1/token/token.dal.ts
@@ -1,13 +1,13 @@
-import type { CreateToken, MongooseObjectId, Token, UpdateToken } from "@ansospace/types";
+import type { CreateToken, ObjectId, Token, UpdateToken } from "@ansospace/types";
 
 import { TokenModel } from "./token.model.js";
 
 interface ITokenDal {
   saveToken(data: Token): Promise<CreateToken>;
   getToken(token: string): Promise<Token | null>;
-  getTokensByUserId(userId: MongooseObjectId): Promise<Token[] | null>;
-  updateToken(tokenId: MongooseObjectId, data: Token): Promise<Token | null>;
-  deleteToken(tokenId: MongooseObjectId): Promise<Token | null>;
+  getTokensByUserId(userId: ObjectId): Promise<Token[] | null>;
+  updateToken(tokenId: ObjectId, data: Token): Promise<Token | null>;
+  deleteToken(tokenId: ObjectId): Promise<Token | null>;
   upsertToken(createTokenSchema: CreateToken): Promise<Token | null>;
 }
 
@@ -20,15 +20,15 @@ export class TokenDAL implements ITokenDal {
     return await TokenModel.findOne({ token });
   }
 
-  async getTokensByUserId(userId: MongooseObjectId): Promise<Token[] | null> {
+  async getTokensByUserId(userId: ObjectId): Promise<Token[] | null> {
     return await TokenModel.find({ userId });
   }
 
-  async updateToken(tokenId: MongooseObjectId, data: UpdateToken): Promise<Token | null> {
+  async updateToken(tokenId: ObjectId, data: UpdateToken): Promise<Token | null> {
     return await TokenModel.findByIdAndUpdate(tokenId, data, { new: true });
   }
 
-  async deleteToken(tokenId: MongooseObjectId): Promise<Token | null> {
+  async deleteToken(tokenId: ObjectId): Promise<Token | null> {
     return await TokenModel.findByIdAndDelete(tokenId);
   }
 

--- a/src/api/v1/token/token.service.ts
+++ b/src/api/v1/token/token.service.ts
@@ -1,4 +1,4 @@
-import { type CreateToken, type MongooseObjectId, type Token, TokenType } from "@ansospace/types";
+import { type CreateToken, type ObjectId, type Token, TokenType } from "@ansospace/types";
 import { isPast } from "date-fns";
 
 import { ErrorTypeEnum, FIVE_MINUTES_IN_MS, UserActionType } from "@/constants";
@@ -13,7 +13,7 @@ export class TokenService {
     this.tokenDAL = new TokenDAL();
   }
 
-  async createActionToken(userId: MongooseObjectId, action: UserActionType) {
+  async createActionToken(userId: ObjectId, action: UserActionType) {
     const token = generateActionToken({ userId, action });
 
     const tokenPayload: CreateToken = {
@@ -52,7 +52,7 @@ export class TokenService {
     }
   }
 
-  async invalidateToken(tokenId: MongooseObjectId) {
+  async invalidateToken(tokenId: ObjectId) {
     await this.tokenDAL.updateToken(tokenId, { isUsed: true });
   }
 }

--- a/src/api/v1/user/user.controller.ts
+++ b/src/api/v1/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { mongooseObjectId, registerSchema, usernameSchema } from "@ansospace/types";
+import { objectId, registerSchema, usernameSchema } from "@ansospace/types";
 import type { Request, Response } from "express";
 
 import { DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET, STATUS_CODES } from "@/constants";
@@ -51,7 +51,7 @@ export const getUserByUsername = async (req: Request, res: Response) => {
 };
 
 export const softDeleteUser = async (req: Request, res: Response) => {
-  const userId = mongooseObjectId.parse(req.params.userId);
+  const userId = objectId.parse(req.params.userId);
 
   const user = await UserService.softDeleteUser(userId);
   sendResponse({
@@ -65,7 +65,7 @@ export const softDeleteUser = async (req: Request, res: Response) => {
 };
 
 export const restoreUser = async (req: Request, res: Response) => {
-  const userId = mongooseObjectId.parse(req.params.userId);
+  const userId = objectId.parse(req.params.userId);
 
   const user = await UserService.restoreUser(userId);
   sendResponse({

--- a/src/api/v1/user/user.dal.ts
+++ b/src/api/v1/user/user.dal.ts
@@ -1,16 +1,8 @@
 // import { type Login } from "../auth/auth.validation.js";
-import type {
-  Login,
-  MongooseObjectId,
-  RegisterSchema,
-  UpdateUser,
-  User,
-  UserRolePermission,
-  Username,
-} from "@ansospace/types";
+import type { Login, ObjectId, RegisterSchema, UpdateUser, User, UserRolePermission, Username } from "@ansospace/types";
 import mongoose from "mongoose";
 
-// import type { MongooseObjectId, Username } from "@/types";
+// import type { ObjectId, Username } from "@/types";
 import { hashPassword } from "@/utils";
 
 import { UserModel } from "./user.model.js";
@@ -50,7 +42,7 @@ export class UserDAL {
     return await UserModel.findOne({ username, isDeleted: false });
   }
 
-  static async getUserById(userId: MongooseObjectId): Promise<User | null> {
+  static async getUserById(userId: ObjectId): Promise<User | null> {
     return await UserModel.findById(userId);
   }
 
@@ -58,22 +50,22 @@ export class UserDAL {
     return await UserModel.findOne({ googleId });
   }
 
-  static async softDeleteUser(userId: MongooseObjectId): Promise<User | null> {
+  static async softDeleteUser(userId: ObjectId): Promise<User | null> {
     return await UserModel.findByIdAndUpdate(userId, { isDeleted: true }, { new: true });
   }
 
-  static async restoreUser(userId: MongooseObjectId): Promise<User | null> {
+  static async restoreUser(userId: ObjectId): Promise<User | null> {
     return await UserModel.findByIdAndUpdate(userId, { isDeleted: false }, { new: true });
   }
 
-  static async updateUser(userId: MongooseObjectId, userData: UpdateUser): Promise<User | null> {
+  static async updateUser(userId: ObjectId, userData: UpdateUser): Promise<User | null> {
     if (userData.password !== null && userData.password !== undefined) {
       userData.password = await hashPassword(userData.password);
     }
     return await UserModel.findByIdAndUpdate(userId, userData, { new: true });
   }
 
-  static async getUserRolesAndPermissionsByUserId(userId: MongooseObjectId): Promise<UserRolePermission> {
+  static async getUserRolesAndPermissionsByUserId(userId: ObjectId): Promise<UserRolePermission> {
     const userRolePermissions = await UserModel.aggregate([
       {
         $match: {

--- a/src/api/v1/user/user.service.ts
+++ b/src/api/v1/user/user.service.ts
@@ -1,7 +1,7 @@
 import {
   type Email,
   type GetUser,
-  type MongooseObjectId,
+  type ObjectId,
   type RegisterSchema,
   type UpdateUser,
   type Username,
@@ -9,7 +9,7 @@ import {
 } from "@ansospace/types";
 
 import { ErrorTypeEnum, ROLES } from "@/constants";
-// import type { Email, MongooseObjectId, Username } from "@/types";
+// import type { Email, ObjectId, Username } from "@/types";
 import { generateRandomUsername } from "@/utils";
 
 import { RoleDAL } from "../role/role.dal.js";
@@ -68,7 +68,7 @@ export class UserService {
     return UserDto(user).getUser();
   }
 
-  static async getUserById(userId: MongooseObjectId): Promise<GetUser> {
+  static async getUserById(userId: ObjectId): Promise<GetUser> {
     const user = await UserDAL.getUserById(userId);
 
     if (!user) throw new Error(ErrorTypeEnum.enum.USER_NOT_FOUND);
@@ -92,7 +92,7 @@ export class UserService {
     return UserDto(user).getUser();
   }
 
-  static async softDeleteUser(userId: MongooseObjectId): Promise<GetUser> {
+  static async softDeleteUser(userId: ObjectId): Promise<GetUser> {
     const user = await UserDAL.softDeleteUser(userId);
 
     if (!user) throw new Error(ErrorTypeEnum.enum.USER_NOT_FOUND);
@@ -100,7 +100,7 @@ export class UserService {
     return UserDto(user).getUser();
   }
 
-  static async restoreUser(userId: MongooseObjectId): Promise<GetUser> {
+  static async restoreUser(userId: ObjectId): Promise<GetUser> {
     const user = await UserDAL.restoreUser(userId);
 
     if (!user) throw new Error(ErrorTypeEnum.enum.USER_NOT_FOUND);
@@ -108,7 +108,7 @@ export class UserService {
     return UserDto(user).getUser();
   }
 
-  static async updateUser(userId: MongooseObjectId, userData: UpdateUser): Promise<GetUser> {
+  static async updateUser(userId: ObjectId, userData: UpdateUser): Promise<GetUser> {
     const updatedUser = await UserDAL.updateUser(userId, userData);
 
     if (!updatedUser) throw new Error(ErrorTypeEnum.enum.INTERNAL_SERVER_ERROR);

--- a/src/api/v1/userRole/__test__/user-role.test.ts
+++ b/src/api/v1/userRole/__test__/user-role.test.ts
@@ -1,4 +1,4 @@
-import type { CreateRole, MongooseObjectId } from "@ansospace/types";
+import type { CreateRole, ObjectId } from "@ansospace/types";
 import mongoose from "mongoose";
 
 import { defaultUsers } from "@/constants";
@@ -21,7 +21,7 @@ const VALID_ROLE: CreateRole = {
 
 describe("User Role Test", () => {
   let authorizationHeader: string;
-  let loggedInUserId: MongooseObjectId;
+  let loggedInUserId: ObjectId;
 
   beforeAll(async () => {
     const loginResponse = await login(defaultUsers);

--- a/src/api/v1/userRole/user-role.dal.ts
+++ b/src/api/v1/userRole/user-role.dal.ts
@@ -1,4 +1,4 @@
-import type { MongooseObjectId, UserRole } from "@ansospace/types";
+import type { ObjectId, UserRole } from "@ansospace/types";
 
 import { UserRoleModel } from "./user-role.model.js";
 
@@ -8,7 +8,7 @@ export class UserRoleDAL {
     return userRolePermission.save();
   }
 
-  static async getUserRoles(userId: MongooseObjectId) {
+  static async getUserRoles(userId: ObjectId) {
     return await UserRoleModel.find({ userId });
   }
 

--- a/src/api/v1/userRole/user-role.service.ts
+++ b/src/api/v1/userRole/user-role.service.ts
@@ -1,4 +1,4 @@
-import type { MongooseObjectId, UserRole } from "@ansospace/types";
+import type { ObjectId, UserRole } from "@ansospace/types";
 
 import { ErrorTypeEnum } from "@/constants";
 
@@ -16,7 +16,7 @@ export class UserRoleService {
     return UserRoleDto(newUserRole).getUserRole();
   }
 
-  static async getUserRoles(userId: MongooseObjectId) {
+  static async getUserRoles(userId: ObjectId) {
     const userRoles = await UserRoleDAL.getUserRoles(userId);
     return userRoles.map((role) => UserRoleDto(role).getUserRole());
   }

--- a/src/config/socket/connection-manager.ts
+++ b/src/config/socket/connection-manager.ts
@@ -1,17 +1,17 @@
-import type { MongooseObjectId, SocketUser } from "@ansospace/types";
+import type { ObjectId, SocketUser } from "@ansospace/types";
 
 class ConnectionManager {
-  private connectedUsers: Map<MongooseObjectId, SocketUser>;
+  private connectedUsers: Map<ObjectId, SocketUser>;
 
   constructor() {
     this.connectedUsers = new Map();
   }
 
-  addUser(userId: MongooseObjectId, socketId: string) {
+  addUser(userId: ObjectId, socketId: string) {
     this.connectedUsers.set(userId, { userId, socketId });
   }
 
-  removeUser(userId: MongooseObjectId) {
+  removeUser(userId: ObjectId) {
     this.connectedUsers.delete(userId);
   }
 
@@ -19,7 +19,7 @@ class ConnectionManager {
     return Array.from(this.connectedUsers.values());
   }
 
-  isUserConnected(userId: MongooseObjectId) {
+  isUserConnected(userId: ObjectId) {
     return this.connectedUsers.has(userId);
   }
 }

--- a/src/utils/__test__/jwt.test.ts
+++ b/src/utils/__test__/jwt.test.ts
@@ -1,4 +1,4 @@
-import type { AccessTokenPayload, MongooseObjectId } from "@ansospace/types";
+import type { AccessTokenPayload, ObjectId } from "@ansospace/types";
 import mongoose from "mongoose";
 import { vi } from "vitest";
 
@@ -28,7 +28,7 @@ describe("Jwt token", () => {
   });
 
   it("should generate a refresh token", () => {
-    const sessionId = new mongoose.Types.ObjectId().toString() as unknown as MongooseObjectId;
+    const sessionId = new mongoose.Types.ObjectId().toString() as unknown as ObjectId;
     const token = generateRefreshToken({ sessionId });
     expect(token).toBeDefined();
   });

--- a/src/utils/__test__/validation.util.test.ts
+++ b/src/utils/__test__/validation.util.test.ts
@@ -1,23 +1,15 @@
-import { emailSchema, mongooseObjectId, usernameSchema } from "@ansospace/types";
-import mongoose from "mongoose";
+import { emailSchema, objectId, usernameSchema } from "@ansospace/types";
 import { describe, expect, it } from "vitest";
 
 // import { validateEmail, validateObjectId, validateUsername } from "@/utils";
 
 describe("validation.util", () => {
   describe("validateObjectId", () => {
-    it("should validate a valid ObjectId string", () => {
-      const validObjectId = new mongoose.Types.ObjectId().toHexString();
-      const result = mongooseObjectId.parse(validObjectId);
-      expect(result).toBeInstanceOf(mongoose.Types.ObjectId);
-      expect(result.toHexString()).toBe(validObjectId);
-    });
-
     it("should throw an error for an invalid ObjectId string", () => {
-      expect(() => mongooseObjectId.parse("invalid-object-id")).toThrow();
-      expect(() => mongooseObjectId.parse(123)).toThrow();
-      expect(() => mongooseObjectId.parse(null)).toThrow();
-      expect(() => mongooseObjectId.parse(undefined)).toThrow();
+      expect(() => objectId.parse("invalid-object-id")).toThrow();
+      expect(() => objectId.parse(123)).toThrow();
+      expect(() => objectId.parse(null)).toThrow();
+      expect(() => objectId.parse(undefined)).toThrow();
     });
   });
 

--- a/src/utils/test/otp.utils.ts
+++ b/src/utils/test/otp.utils.ts
@@ -1,4 +1,4 @@
-import type { MongooseObjectId, OtpEvent, OtpRecord, OtpVerifyEvent } from "@ansospace/types";
+import type { ObjectId, OtpEvent, OtpRecord, OtpVerifyEvent } from "@ansospace/types";
 import supertest, { type Response } from "supertest";
 
 import { success } from "@/api/v1/auth/auth.constant.js";
@@ -22,7 +22,7 @@ export const expectOTPRequestSuccess = (response: Response): void => {
   });
 };
 
-export const retrieveOTP = async (userId: MongooseObjectId, otpType: NotificationType): Promise<OtpRecord> => {
+export const retrieveOTP = async (userId: ObjectId, otpType: NotificationType): Promise<OtpRecord> => {
   const otpDetails = await OtpService.getOtpDetailsByUserId({
     userId,
     otpType,

--- a/src/utils/test/user.utils.ts
+++ b/src/utils/test/user.utils.ts
@@ -1,4 +1,4 @@
-import type { MongooseObjectId, Pagination, RegisterSchema } from "@ansospace/types";
+import type { ObjectId, Pagination, RegisterSchema } from "@ansospace/types";
 import supertest, { type Response } from "supertest";
 
 import { success } from "@/api/v1/user/user.constant.js";
@@ -81,7 +81,7 @@ export const expectFindUserByUsernameSuccess = (response: Response, user: Regist
   expect(body.data).not.toHaveProperty("confirmPassword");
 };
 
-export const deleteUser = async (userId: MongooseObjectId | string, authorizationHeader: string): Promise<Response> => {
+export const deleteUser = async (userId: ObjectId | string, authorizationHeader: string): Promise<Response> => {
   return supertest(app).delete(`/api/v1/users/${userId}`).set("authorization", authorizationHeader);
 };
 
@@ -100,10 +100,7 @@ export const expectDeleteUserSuccess = (response: Response): void => {
   expect(body.data.user).not.toHaveProperty("confirmPassword");
 };
 
-export const restoreUser = async (
-  userId: MongooseObjectId | string,
-  authorizationHeader: string
-): Promise<Response> => {
+export const restoreUser = async (userId: ObjectId | string, authorizationHeader: string): Promise<Response> => {
   return supertest(app).patch(`/api/v1/users/${userId}/restore`).set("authorization", authorizationHeader);
 };
 


### PR DESCRIPTION
Update all occurrences of MongooseObjectId to ObjectId across the codebase to maintain consistency with the updated @ansospace/types package (v0.3.8). This change affects models, services, controllers, and tests.

Update package.json to use @ansospace/types v0.3.8 and adjust pnpm-lock.yaml accordingl

#141